### PR TITLE
Constructor now works again

### DIFF
--- a/openape.js
+++ b/openape.js
@@ -56,7 +56,6 @@ class Client {
     constructor(username, password, serverUrl = openAPE_API.openApeServerUrl, defaultContentType = openAPE_API.defaultContentType) {
         this.defaultContentType = "application/json";
         this.token = null;
-        this.serverUrl = "/" ? window.location.protocol : serverUrl;
         this.defaultContentType = defaultContentType;
 
         console.log("Connection will be established with server: " + this.serverUrl);


### PR DESCRIPTION
Fixes a bug causing the Client constructor to fail when relying on the default value of the server location (in which case localhost would be used, causing the token request to fail)